### PR TITLE
Correcting HTML presentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of documents describing what a Reproducible Analytical Pipeline is 
 > A Reproducible Analytical Pipeline (RAP) brings together code and data to generate outputs. The RAP pipeline is built within a version control system (e.g. `git`) to create a transparent production process.
 
 ## Resources list
-- [Introduction to RAP presentation](https://github.com/datasciencecampus/gov-uk-rap-materials/raw/master/gov-uk-rap-project-materials.html)
+- [Introduction to RAP presentation](https://github.com/datasciencecampus/gov-uk-rap-materials/blob/master/gov-uk-rap-materials_intro-to-rap.html)
     * A presentation introducing the concept of RAP and why it is useful
     * Download this `html` document and double click it to view the presentation
     * This presentation was built using the `Rmarkdown` `ioslides` presentation template. Take a look at the code [here](https://github.com/datasciencecampus/gov-uk-rap-materials/blob/master/gov-uk-rap-project-materials.Rmd)


### PR DESCRIPTION
The link to the HTML presentation failed for me when browsing on GitHub on the web.